### PR TITLE
Update help command to reflect user guide

### DIFF
--- a/src/main/java/vitalconnect/ui/HelpWindow.java
+++ b/src/main/java/vitalconnect/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import vitalconnect.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w08-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
Resolving #7 

The default implementation of the help command leads to the ab3 website instead of the project's user guide.

Modified the link to redirect to the proper location.